### PR TITLE
Error in getTEvents

### DIFF
--- a/notebooks/Labeling and MetaLabeling for Supervised Classification.ipynb
+++ b/notebooks/Labeling and MetaLabeling for Supervised Classification.ipynb
@@ -179,10 +179,10 @@
    "source": [
     "def getTEvents(gRaw, h):\n",
     "    tEvents, sPos, sNeg = [], 0, 0\n",
-    "    diff = np.log(gRaw).diff().dropna().abs()\n",
+    "    diff = np.log(gRaw).diff().dropna()\n",
     "    for i in tqdm(diff.index[1:]):\n",
     "        try:\n",
-    "            pos, neg = float(sPos+diff.loc[i]), float(sNeg-diff.loc[i])\n",
+    "            pos, neg = float(sPos+diff.loc[i]), float(sNeg+diff.loc[i])\n",
     "        except Exception as e:\n",
     "            print(e)\n",
     "            print(sPos+diff.loc[i], type(sPos+diff.loc[i]))\n",

--- a/notebooks/Labeling and MetaLabeling for Supervised Classification.ipynb
+++ b/notebooks/Labeling and MetaLabeling for Supervised Classification.ipynb
@@ -182,7 +182,7 @@
     "    diff = np.log(gRaw).diff().dropna().abs()\n",
     "    for i in tqdm(diff.index[1:]):\n",
     "        try:\n",
-    "            pos, neg = float(sPos+diff.loc[i]), float(sNeg+diff.loc[i])\n",
+    "            pos, neg = float(sPos+diff.loc[i]), float(sNeg-diff.loc[i])\n",
     "        except Exception as e:\n",
     "            print(e)\n",
     "            print(sPos+diff.loc[i], type(sPos+diff.loc[i]))\n",


### PR DESCRIPTION
It seems this error goes all the way back to the code provided in the book.  Really appreciate you making your examples available.
   
`sNeg` is off by a minus sign causing it to be reset to 0 every loop.  `sNeg<-h ` is never executed.  Events are only being triggered on the positive side (`sPos>h`).  Subtracting `diff.loc[i]` seems to be the easiest fix but you might prefer a different way.